### PR TITLE
Add a confirmation intent rule

### DIFF
--- a/SmallTalks/SmallTalks.Core/Resources/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/intents.json
@@ -17,7 +17,7 @@
                 "tudo bem",
                 "confirmo",
                 "^isso+$",
-
+                "^ss?$"
             ],
             "priority": 3
         },


### PR DESCRIPTION
Today when the input is "n", a negation intent is identified, that PR is a fix to confirmation intent to identify when the input is "s" or "ss".