### PR TITLE
 Change from dotnet core to dotnet standard and fix greetings "eai" pattern

### DIFF
--- a/SmallTalks/SmallTalks.Core/Resources/v1/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/v1/intents.json
@@ -170,6 +170,7 @@
             "name": "Thank",
             "rules": [
                 "^(muito\\s+)?obrigad.",
+                "obrigad.(\\s+|\\.)?",
                 "valeu(\\s+(demais|por tudo|muito))?",
                 "vlw(\\s+(demais|por tudo|muito))?",
                 "muito obg",

--- a/SmallTalks/SmallTalks.Core/Resources/v1/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/v1/intents.json
@@ -77,7 +77,7 @@
                 "algu.m a[ií]+",
                 "al[oô]",
                 "hey",
-                "eae",
+                "ea(e|[ií])",
                 "opa",
                 "hello",
                 "hi",

--- a/SmallTalks/SmallTalks.Core/Resources/v2/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/v2/intents.json
@@ -206,7 +206,7 @@
                 "al[oô]",
                 "blz\\?",
                 "hey",
-                "eae",
+                "ea(e|[ií])",
                 "e\\s*a[ií]",
                 "hello",
                 "hi",

--- a/SmallTalks/SmallTalks.Core/Resources/v2/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/v2/intents.json
@@ -274,6 +274,7 @@
                 "(o?briga[dg].|obg)\\s+(demais|por\\s*tudo|muito|mto|d\\+)",
                 "(a[jg]udou?)?\\s*(muito|mto)?\\s*(o?briga[dg].|obg)",
                 "(de|por) nada",
+                "obrigad.(\\s+|\\.)?",
                 "muito obg",
                 "obg",
                 "merci",

--- a/SmallTalks/SmallTalks.Core/Services/ModelConversionService.cs
+++ b/SmallTalks/SmallTalks.Core/Services/ModelConversionService.cs
@@ -21,7 +21,7 @@ namespace SmallTalks.Core.Services
                 .Select(p => Regex.IsMatch(p, "^\\w") ? $"\\b{p}" : p)
                 .Select(p => Regex.IsMatch(p, "\\w$") ? $"{p}\\b" : p)
                 .ToList();
-            var regexPattern = string.Join('|', patters);
+            var regexPattern = string.Join("|", patters);
 
             stIntent.Regex = new Regex(regexPattern, Configuration.ST_REGEX_OPTIONS);
             stIntent.Priority = rule.Priority;
@@ -42,7 +42,7 @@ namespace SmallTalks.Core.Services
                 .Select(p => RegexAdd(rule.Position, p))
                 .ToList();
             var finalPatterns = patterns.SelectMany(x => x).ToList();
-            var regexPattern = string.Join('|', finalPatterns);
+            var regexPattern = string.Join("|", finalPatterns);
 
             stIntent.Regex = new Regex(regexPattern, Configuration.ST_REGEX_OPTIONS);
             stIntent.Priority = rule.Priority;

--- a/SmallTalks/SmallTalks.Core/SmallTalks.Core.csproj
+++ b/SmallTalks/SmallTalks.Core/SmallTalks.Core.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SmallTalks/SmallTalks.Core/SmallTalks.Core.csproj
+++ b/SmallTalks/SmallTalks.Core/SmallTalks.Core.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Lime.Protocol" Version="0.7.278" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Dotnet standard provides support for all runtimes(dotnet core, mono, dotnet framework).
A little fix to greetings pattern to identify when the input is "eai".