### PR TITLE
Added back all the smalltalks identifided into the body response.

### DIFF
--- a/SmallTalks/Entities.Core/Extensions/InputProcessExtension.cs
+++ b/SmallTalks/Entities.Core/Extensions/InputProcessExtension.cs
@@ -7,7 +7,7 @@ namespace Entities.Domain.Extensions
 {
     public static class InputProcessExtension
     {
-        public static Regex PunctuationRegex = new Regex("[\\.,\\/#!\\$%\\^&\\*;:{}=\\-_`~()\\?\\\\]", RegexOptions.Compiled);
+        public static Regex PunctuationRegex = new Regex("[\\.,\\/#!\\$%\\^&\\*;:{}=\\-_`~()\\\\]", RegexOptions.Compiled);
 
         public static InputProcess RemoveRepeteadChars(this InputProcess inputProcess)
         {

--- a/SmallTalks/SmallTalks.Core.Tests/EnsureMatchSource.tsv
+++ b/SmallTalks/SmallTalks.Core.Tests/EnsureMatchSource.tsv
@@ -16,6 +16,9 @@ não sei...	Confusion:1
 não entendi	Confusion:1
 como assim	Confusion:1
 como assim cara???	Confusion:1
+o que?	Confusion:1
+que?	Confusion:1
+que	Confusion:0
 concordo	Consent:1
 blz	Consent:1
 beleza	Consent:1

--- a/SmallTalks/SmallTalks.Core.Tests/EnsureMatchSourcev2.tsv
+++ b/SmallTalks/SmallTalks.Core.Tests/EnsureMatchSourcev2.tsv
@@ -1,8 +1,4 @@
-﻿tudo bem então ok	Consent:1
-tudo certo obrigada e tchau	Goodbye:1
-tudo certo com o meu problema	Thanks:1
-tudo certo obrigada	Thanks:1
-eu amo voce	Compliment:1
+﻿eu amo voce	Compliment:1
 eu te amo	Compliment:1
 vc e linda	Compliment:1
 voce e linda	Compliment:1
@@ -89,8 +85,12 @@ boiei	Confusion:1
 não saquei	Confusion:1
 ?????	Confusion:1
 ?	Confusion:1
+o que?	Confusion:1
+que?	Confusion:1
+que	Confusion:0
 concordo	Consent:1
 blz	Consent:1
+tudo bem então ok	Consent:1
 beleza	Consent:1
 aceito	Consent:1
 beleza então está bom	Consent:1
@@ -136,8 +136,8 @@ beijo	Goodbye:1
 beijos	Goodbye:1
 bjs	Goodbye:1
 bjos	Goodbye:1
-obrigada e até mais	GoodBye:1
-tchau e até a próxima	Goodbye:1
+tchau e até a próxima	Goodbye:2
+tudo certo obrigada e tchau	Goodbye:1
 finalizar o fluxo agora	Goodbye:1
 esta bem então até a próxima	Goodbye:1
 estou saindo do canal	Goodbye:1
@@ -164,6 +164,8 @@ boooaaaaa noiteeeeee	GoodNight:1
 boooaaaaa noiiiteeeeee	GoodNight:1
 opa!	Greeting:1
 opa	Greeting:1
+blz?	Greeting:1
+hello	Greeting:1
 opa! blz? To precisando falar com alguem...	Greeting:1
 oi, bom dia	Greeting:1
 colé fi?	Greeting:1
@@ -174,7 +176,6 @@ olaáááá	Greeting:1
 ois	Greeting:1
 oiê	Greeting:1
 opa!, colé?	Greeting:1
-blz?	Greeting:1
 oi	Greeting:1
 alguém em casa?	Greeting:1
 alguem em casa?	Greeting:1
@@ -186,7 +187,6 @@ Eae	Greeting:1
 e ae	Greeting:1
 Oi	Greeting:1
 hi	Greeting:1
-hello	Greeting:1
 Oie!	Greeting:1
 Eae	Greeting:1
 Ei!	Greeting:1
@@ -197,8 +197,6 @@ cole	Greeting:1
 e ai	Greeting:1
 e aí	Greeting:1
 qualé	Greeting:1
-nnn	Negation:0
-nnn	Negation:0
 assim naum	Negation:1
 assim nao precisa 	Negation:1
 nao obrigada	Negation:1
@@ -206,6 +204,7 @@ n tenho interesse	Negation:1
 ta bom mas não precisa	Negation:1
 não quero	Negation:1
 não	Negation:1
+nnnnnnnnnnnnnnnnn	Negation:1
 nunca	Negation:1
 jamais	Negation:1
 naum	Negation:1
@@ -260,11 +259,15 @@ Obrigado você	Thanks:1
 Obrigada você	Thanks:1
 brigado	Thanks:1
 brigaga	Thanks:1
+tudo certo com o meu problema	Thanks:1
 ajudou muito obrigada	Thanks:1
 ta bom obrigada demais	Thanks:1
 valeu demais obrigada	Thanks:1
 o atendente resolveu já	Thanks:1
 vocês me ajudaram	Thanks:1
+obrigada e tchau valeu	Thanks:2
+obrigada e até mais	Thanks:1,GoodBye:1
+tudo certo obrigada	Thanks:1
 vocês me responderam o que queria	Thanks:1
 então até mais e obrigada	Thanks:1
 estou feliz e satisfeita	Thanks:1
@@ -275,7 +278,6 @@ já falei com atendente	Thanks:1
 já fui atendido	Thanks:1
 já me atenderam	Thanks:1
 já resolveram o meu problema	Thanks:1
-obrigada e tchau valeu	Thanks:1
 Obrigado para você também	Thanks:1
 oitenta	Greeting:0
 poderia receber valores de vendas no CNOJ?	Confirmation:0

--- a/SmallTalks/SmallTalks.Core/ISmallTalksDetector.cs
+++ b/SmallTalks/SmallTalks.Core/ISmallTalksDetector.cs
@@ -5,9 +5,9 @@ namespace SmallTalks.Core
 {
     public interface ISmallTalksDetector
     {
-        SmallTalksDectectorData DectectorData { get; }
+        SmallTalksDectectorData DetectorData { get; }
 
-        SmallTalksDectectorData DectectorDatav2 { get; }
+        SmallTalksDectectorData DetectorDatav2 { get; }
 
         Task<Analysis> DetectAsync(string input);
 

--- a/SmallTalks/SmallTalks.Core/Models/MatchData.cs
+++ b/SmallTalks/SmallTalks.Core/Models/MatchData.cs
@@ -9,6 +9,6 @@ namespace SmallTalks.Core.Models
         public string SmallTalk { get; internal set; }
         public string Value { get; internal set; }
         public int? Index { get; internal set; }
-        public int? Lenght { get; internal set; }
+        public int? Length { get; internal set; }
     }
 }

--- a/SmallTalks/SmallTalks.Core/Resources/cursewords.txt
+++ b/SmallTalks/SmallTalks.Core/Resources/cursewords.txt
@@ -33,8 +33,7 @@ Tosc.s?
 Peidos?
 Babacas?
 Corn.s?
-Pau
-Chupa
+(peg[a@]|l[a@]mb[ei]|xup[a@]|chup[a@])\s*(([ou]|n[ou])\s*)?(me[uo]\s*)?p[a@][ul]?
 Pica
 Cacete
 Toba

--- a/SmallTalks/SmallTalks.Core/Resources/v1/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/v1/intents.json
@@ -37,7 +37,8 @@
         {
             "name": "Confusion",
             "rules": [
-                "como assim",
+                "(o\\s*)?(qu[eê]|q)\\?",
+                "como a(ss|s|ç)im",
                 "não sei",
                 "não entendi"
             ],

--- a/SmallTalks/SmallTalks.Core/Resources/v2/intents.json
+++ b/SmallTalks/SmallTalks.Core/Resources/v2/intents.json
@@ -60,11 +60,12 @@
         {
             "name": "Confusion",
             "rules": [
-                "como assim",
-                "não sei",
-                "não entendi",
-                "boiei",
                 "(n[aãâ]o+|nn?|naum|nem|jamais)(\\s*)saquei\\b",
+                "(o\\s*)?(qu[eê]|q)\\?",
+                "(n[ãaâ]o|naum) entendi?",
+                "(n[ãaâ]o|naum) sei",
+                "como a(ss|ç|s)im",
+                "boiei",
                 "\\?+"
             ],
             "position": [
@@ -78,7 +79,7 @@
                 "(beleza|blza)(\\s*)(ent[aãâ]o|ent[aãâ]um)?\\b(\\s*)((est[aá]|t[aá])(\\s*)(bem|bm|bom))?\\b",
                 "(tudo|td)(\\s*)(bem|bm)(\\s*)(ent[aãâ]o|ent[aãâ]um)(\\s*)(o(quei|kay|kei|key|ka|k)+)?\\b",
                 "concordo",
-                "blz",
+                "blz?",
                 "beleza",
                 "aceito"
             ],
@@ -136,17 +137,14 @@
                 "(finalizar|terminar|encerrar|acabar)\\s*([ao])?\\s*(fluxo|co[mn]ver[sç]a)\\s*(agora)?\\b",
                 "(estou|t[oô])\\s*(saind?[ou])\\s*((d[aeo])\\s*(canal|bot))?\\b",
                 "at[ée]\\s*a\\s*pr[óo]xima(\\s+vez)?\\b",
-                "at[ée]\\s*(mais|\\+)(\\s+tarde)?\\b",
+                "at[ée]\\s*(mais|\\+|logo)(\\s+(tarde|ver))?\\b",
                 "abra[çc]os?\\s*e\\s*beijo?\\b",
                 "abra[çc]os?\\s*e\\s*bjos?",
-                "at[eé]\\s*mais ver",
-                "at[ée]\\s*logo",
                 "um\\s*abraço",
                 "int[eé]\\b",
                 "at[eé]\\b",
                 "abra[çc]o",
-                "flws?",
-                "falows",
+                "fa?lo?ws?",
                 "falou",
                 "sair*"
 
@@ -213,7 +211,7 @@
                 "hey",
                 "e\\s*a(e|[ií])",
                 "e\\s*a[ií]",
-                "hello",
+                "hell?o",
                 "hi",
                 "ei"
             ],


### PR DESCRIPTION
Added new examples into Confusion intent. Fixed a mistaken cursed word match.

Morover, added the punctuation removal to the input before checking for smalltalks because there is no reason to identify punctuation. The only exception is the question mark. It can change which smalltalk should be matched when it's or not in a sentence.